### PR TITLE
add dynamic time warp distance as an option for time varying descriptors

### DIFF
--- a/audioguide/simcalc.py
+++ b/audioguide/simcalc.py
@@ -286,7 +286,7 @@ def dtwDist(x,y):
 
 	try:
 		from scipy.spatial.distance import euclidean
-	except ImportError
+	except ImportError:
 		print(ImportError, "scipy package is not installed.")
 	"""Dynamic Time Warping Distance"""
 	dist, _ = fastdtw(x, y, distance=euclidian)

--- a/audioguide/simcalc.py
+++ b/audioguide/simcalc.py
@@ -289,7 +289,7 @@ def dtwDist(x,y):
 	except ImportError:
 		print(ImportError, "scipy package is not installed.")
 	"""Dynamic Time Warping Distance"""
-	dist, _ = fastdtw(x, y, dist=euclidian)
+	dist, _ = fastdtw(x, y, dist=euclidean)
 	return dist
 
 

--- a/audioguide/simcalc.py
+++ b/audioguide/simcalc.py
@@ -275,6 +275,22 @@ def pearsonCorr(x,y):
 	den = pow((sum_x_sq - pow(sum_x, 2) / n) * (sum_y_sq - pow(sum_y, 2) / n), 0.5)
 	if den == 0: return 0
 	return num / den
+
+def dtwDist(x,y):
+	try:
+		from fastdtw import dtw
+	except ImportError:
+		print(ImportError, "fastdtw package is not installed.")
+
+	try:
+		from scipy.spatial.distance import euclidean
+	except ImportError
+		print(ImportError, "scipy package is not installed.")
+	"""Dynamic Time Warping Distance"""
+	dist, _ = fastdtw(x, y, distance=euclidian)
+	return dist
+
+
 	
 
 

--- a/audioguide/simcalc.py
+++ b/audioguide/simcalc.py
@@ -280,7 +280,7 @@ def pearsonCorr(x,y):
 
 def dtwDist(x,y):
 	try:
-		from fastdtw import dtw
+		from fastdtw import fastdtw
 	except ImportError:
 		print(ImportError, "fastdtw package is not installed.")
 
@@ -289,7 +289,7 @@ def dtwDist(x,y):
 	except ImportError:
 		print(ImportError, "scipy package is not installed.")
 	"""Dynamic Time Warping Distance"""
-	dist, _ = fastdtw(x, y, distance=euclidian)
+	dist, _ = fastdtw(x, y, dist=euclidian)
 	return dist
 
 

--- a/audioguide/simcalc.py
+++ b/audioguide/simcalc.py
@@ -218,6 +218,8 @@ def timeVaryingDistance(array1, array2, dist=None, envelopeMask=None, energyWeig
 		return pearsonCorr(array1[0:l], array2[0:l])
 	elif dist == 'kullback':
 		return kullback(array1, array2)
+	elif dist == "dtw":
+		return dtwDist(array1, array2)
 	elif dist.find('fixedSize') != -1: # written as fixedSize-2, fixedSize-4, etc.
 		return fixedSizeDigest(array1, array2, dist, peaks) # divided by the length
 	else:


### PR DESCRIPTION
This adds the dynamic time warping distance as an option for comparing two time series. Perhaps AudioGuide doesn't benefit so much from the power of DTW, as I believe its strength is comparing time series that are different sizes. From what I can tell two AG always compares two arrays of the same size. However, dtw might add some flexibility for comparing time series of unequal lengths in future which could be used to time stretch samples as matches for example.

Anyway, the PR is here if you want to check that out.

It does require:

`pip install fastdtw scipy`